### PR TITLE
Enable syntax-highlighted diffs

### DIFF
--- a/lua/onedarkpro/colors/onedark.lua
+++ b/lua/onedarkpro/colors/onedark.lua
@@ -21,6 +21,9 @@ function M.load(config)
 		black = "#1e1e1e",
 		gray = "#5c6370",
 		highlight = "#e2be7d",
+		diff_add_bg = "#152d24",
+		diff_delete_bg = "#301a1f",
+		diff_text_bg = "#454a54",
 		none = "NONE",
 	}
 

--- a/lua/onedarkpro/colors/onedark.lua
+++ b/lua/onedarkpro/colors/onedark.lua
@@ -21,9 +21,9 @@ function M.load(config)
 		black = "#1e1e1e",
 		gray = "#5c6370",
 		highlight = "#e2be7d",
-		diff_add_bg = "#152d24",
-		diff_delete_bg = "#301a1f",
-		diff_text_bg = "#454a54",
+		diff_add_bg = "#003e4a",
+		diff_delete_bg = "#501b20",
+		diff_text_bg = "#005869",
 		none = "NONE",
 	}
 

--- a/lua/onedarkpro/colors/onelight.lua
+++ b/lua/onedarkpro/colors/onelight.lua
@@ -21,6 +21,9 @@ function M.load(config)
 		black = "#6a6a6a",
 		gray = "#bebebe",
 		highlight = "#e2be7d",
+		diff_add_bg = "#cae3e8",
+		diff_delete_bg = "#f5c6c6",
+		diff_text_bg = "#a6d0d8",
 		none = "NONE",
 	}
 

--- a/lua/onedarkpro/theme.lua
+++ b/lua/onedarkpro/theme.lua
@@ -31,10 +31,10 @@ function M.apply(colors, config)
 		CursorLine = { bg = theme.cursorline }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
 		CursorLineNr = { bg = theme.cursorline, fg = c.purple, style = theme.bold }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
 		Directory = { fg = c.blue }, -- directory names (and other special names in listings)
-		DiffAdd = { bg = c.green }, -- diff mode: Added line |diff.txt|
+		DiffAdd = { bg = c.diff_add_bg }, -- diff mode: Added line |diff.txt|
 		DiffChange = { style = theme.underline }, -- diff mode: Changed line |diff.txt|
-		DiffDelete = { bg = c.red },
-		DiffText = { bg = c.yellow }, -- diff mode: Changed text within a changed line |diff.txt|
+		DiffDelete = { bg = c.diff_delete_bg },
+		DiffText = { bg = c.diff_text_bg }, -- diff mode: Changed text within a changed line |diff.txt|
 		EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
 		-- TermCursor   = {}, -- cursor in a focused terminal
 		-- TermCursorNC = {}, -- cursor in an unfocused terminal

--- a/lua/onedarkpro/theme.lua
+++ b/lua/onedarkpro/theme.lua
@@ -31,10 +31,10 @@ function M.apply(colors, config)
 		CursorLine = { bg = theme.cursorline }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
 		CursorLineNr = { bg = theme.cursorline, fg = c.purple, style = theme.bold }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
 		Directory = { fg = c.blue }, -- directory names (and other special names in listings)
-		DiffAdd = { bg = c.green, fg = c.black }, -- diff mode: Added line |diff.txt|
-		DiffChange = { fg = c.yellow, style = theme.underline }, -- diff mode: Changed line |diff.txt|
-		DiffDelete = { bg = c.red, fg = c.bg },
-		DiffText = { bg = c.yellow, fg = c.bg }, -- diff mode: Changed text within a changed line |diff.txt|
+		DiffAdd = { bg = c.green }, -- diff mode: Added line |diff.txt|
+		DiffChange = { style = theme.underline }, -- diff mode: Changed line |diff.txt|
+		DiffDelete = { bg = c.red },
+		DiffText = { bg = c.yellow }, -- diff mode: Changed text within a changed line |diff.txt|
 		EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
 		-- TermCursor   = {}, -- cursor in a focused terminal
 		-- TermCursorNC = {}, -- cursor in an unfocused terminal


### PR DESCRIPTION
Hi there! Thanks for the theme!

This PR allows syntax highlighting to be used in diffs, and sets some default diff background colors that go well with that change. The result is (intentionally) similar to GitHub's diff rendering.

Hope this is helpful!

Before:

![image](https://user-images.githubusercontent.com/524994/140584364-5e10efd8-0a68-4115-81cd-d510a5a05cfb.png)

After:

![image](https://user-images.githubusercontent.com/524994/140584865-76456be2-1977-48f0-a859-c20fe2aa295d.png)

Instead of changing the theme's defaults, I imagine it would also be possible to allow the fg colors I removed to be disabled from the plugin's settings, so that users would have the option to use syntax highlighting if they wanted.

## Changes

- Remove the fg color on diff lines so that normal syntax colors are used
- Use darker background colors for the diffs, so that the text (which is no longer dark) is still legible

## Notes

- If there is already a way to override the fg colors set for diffs [here](https://github.com/olimorris/onedarkpro.nvim/blob/main/lua/onedarkpro/theme.lua#L34-L37) without modifying the theme files, then this PR isn't needed. I couldn't figure out how.
- I just implemented this and it's barely tested. I'm sure there are ways to improve the colors I chose!
- I haven't added anything equivalent to the light theme.