### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ options = {
 
 #### Cursorline
 
-Cursorline highlighting is supported in the colorscheme using a `cursorline` color (which may of course be overriden). This can be enabled with the following:
+Cursorline highlighting is supported in the colorscheme using a `cursorline` color (which may of course be overridden). This can be enabled with the following:
 
 ```lua
 colors = {

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ require("onedarkpro").setup({
       cursorline = false, -- Use cursorline highlighting?
       transparency = false, -- Use a transparent background?
       terminal_colors = false, -- Use the colorscheme's colors for Neovim's :terminal?
-      window_unfocussed_color = false, -- When the window is out of focus, change the normal background?
+      window_unfocused_color = false, -- When the window is out of focus, change the normal background?
   }
 })
 ```
@@ -346,11 +346,11 @@ options = {
 
 #### Window Focus Color
 
-The colorscheme supports changing the color of the main window in Neovim when focussed is lost. For example, when a `telescope` or `packer` pop up appears:
+The colorscheme supports changing the color of the main window in Neovim when the focus is lost. For example, when a `telescope` or `packer` pop up appears:
 
 ```lua
 options = {
-  window_unfocussed_color = true
+  window_unfocused_color = true
 }
 ```
 

--- a/lua/onedarkpro/config.lua
+++ b/lua/onedarkpro/config.lua
@@ -89,7 +89,7 @@ local defaults = {
         cursorline = false, -- Use cursorline highlighting?
         transparency = false, -- Use a transparent background?
         terminal_colors = false, -- Use the theme's colors for Neovim's :terminal?
-        window_unfocussed_color = false, -- When the window is out of focus, change the normal background?
+        window_unfocused_color = false, -- When the window is out of focus, change the normal background?
     },
 }
 
@@ -110,7 +110,8 @@ local function set_options(opts)
         cursorline = opts.cursorline or opts.highlight_cursorline,
         transparency = opts.transparency or opts.transparent,
         terminal_colors = opts.terminal_colors,
-        window_unfocussed_color = opts.window_unfocussed_color,
+        -- keep unfocussed (typo) to prevent breaking existing config
+        window_unfocused_color = opts.window_unfocused_color or opts.window_unfocussed_color,
     }
 
     return M.config.options

--- a/lua/onedarkpro/highlights/editor.lua
+++ b/lua/onedarkpro/highlights/editor.lua
@@ -39,7 +39,7 @@ function M.groups(theme)
         Normal = { bg = config.options.transparency and "NONE" or theme.palette.bg, fg = theme.palette.fg }, -- normal text
         NormalNC = {
             bg = config.options.transparency and "NONE"
-                or config.options.window_unfocussed_color and theme.generated.color_column
+                or config.options.window_unfocused_color and theme.generated.color_column
                 or theme.palette.bg,
             fg = theme.palette.fg,
         }, -- normal text in non-current windows
@@ -83,14 +83,14 @@ function M.groups(theme)
         StatusLine = { bg = config.options.transparency and "NONE" or theme.palette.bg, fg = theme.palette.fg }, -- status line of current window
         StatusLineNC = {
             bg = config.options.transparency and "NONE"
-                or config.options.window_unfocussed_color and theme.generated.color_column
+                or config.options.window_unfocused_color and theme.generated.color_column
                 or theme.palette.bg,
             fg = theme.palette.fg,
         }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
         TabLine = { bg = config.options.transparency and "NONE" or theme.palette.bg }, -- tab pages line, not active tab page label
         TabLineFill = { bg = config.options.transparency and "NONE" or theme.palette.bg, fg = theme.palette.fg }, -- tab pages line, where there are no labels
         TabLineSel = { bg = theme.palette.gray, fg = theme.palette.purple }, -- tab pages line, active tab page label
-                TermCursor = { bg = theme.palette.purple }, -- cursor in a focused terminal
+        TermCursor = { bg = theme.palette.purple }, -- cursor in a focused terminal
         TermCursorNC = { bg = theme.palette.gray }, -- cursor in an unfocused terminal
         Title = { fg = theme.palette.green }, -- titles for output from ":set all", ":autocmd"
         Visual = { bg = theme.generated.selection }, -- Visual mode selection
@@ -99,7 +99,7 @@ function M.groups(theme)
         WinBar = { bg = config.options.transparency and "NONE" or theme.palette.bg, fg = theme.palette.fg },
         WinBarNC = {
             bg = config.options.transparency and "NONE"
-                or config.options.window_unfocussed_color and theme.generated.color_column
+                or config.options.window_unfocused_color and theme.generated.color_column
                 or theme.palette.bg,
             fg = theme.palette.fg,
         },

--- a/lua/onedarkpro/highlights/plugins/neo_tree.lua
+++ b/lua/onedarkpro/highlights/plugins/neo_tree.lua
@@ -9,7 +9,7 @@ function M.groups(theme)
     return {
         NeoTreeNormalNC = { -- Color when nvim-tree is no longer in focus
             bg = config.options.transparency and "NONE"
-                or (config.options.window_unfocussed_color and theme.generated.color_column or theme.palette.bg),
+                or (config.options.window_unfocused_color and theme.generated.color_column or theme.palette.bg),
         },
         NeoTreeSymbolicLinkTarget = {
             fg = theme.palette.cyan,

--- a/lua/onedarkpro/highlights/plugins/nvim_tree.lua
+++ b/lua/onedarkpro/highlights/plugins/nvim_tree.lua
@@ -8,7 +8,8 @@ function M.groups(theme)
 
     return {
         NvimTreeNormalNC = { -- Color when nvim-tree is no longer in focus
-            bg = config.options.transparency and "NONE" or (config.options.window_unfocussed_color and theme.generated.color_column or theme.palette.bg),
+            bg = config.options.transparency and "NONE"
+                or (config.options.window_unfocused_color and theme.generated.color_column or theme.palette.bg),
         },
         NvimTreeSymlink = {
             fg = theme.palette.cyan,

--- a/lua/onedarkpro/highlights/plugins/treesitter.lua
+++ b/lua/onedarkpro/highlights/plugins/treesitter.lua
@@ -27,7 +27,7 @@ function M.groups(theme)
             style = config.styles.functions,
         }, -- For function (calls and definitions).
         TSFuncBuiltin = { fg = theme.palette.yellow }, -- For builtin functions: `table.insert` in Lua.
-        TSFuncMacro = { fg = theme.palette.blue }, -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
+        TSFuncMacro = { fg = theme.palette.blue }, -- For macro defined functions (calls and definitions): each `macro_rules` in Rust.
         TSInclude = { fg = theme.palette.purple, style = config.options.italic }, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
         TSKeyword = {
             fg = theme.palette.purple,
@@ -36,7 +36,7 @@ function M.groups(theme)
         TSKeywordFunction = {
             fg = theme.palette.purple,
             style = config.styles.keywords,
-        }, -- For keywords used to define a fuction.
+        }, -- For keywords used to define a function.
         TSKeywordOperator = {
             fg = theme.palette.purple,
             style = config.options.italic,
@@ -53,7 +53,7 @@ function M.groups(theme)
         TSProperty = { fg = theme.palette.red }, -- Same as `TSField`.
         TSPunctDelimiter = { link = "Delimiter" }, -- For delimiters ie: `.`
         TSPunctBracket = { fg = theme.palette.fg }, -- For brackets and parens.
-        TSPunctSpecial = { fg = theme.palette.fg }, -- For special punctutation that does not fall in the catagories before.
+        TSPunctSpecial = { fg = theme.palette.fg }, -- For special punctutation that does not fall in the categories before.
         TSRepeat = { fg = theme.palette.purple, style = config.options.italic }, -- For keywords related to loops.
         TSString = {
             fg = theme.palette.green,

--- a/lua/onedarkpro/main.lua
+++ b/lua/onedarkpro/main.lua
@@ -66,7 +66,7 @@ local function set_info(theme)
         require("onedarkpro.utils.collect").deep_extend(theme.palette, theme.generated, theme.meta)
 end
 
----Carry out the neccessary work to load the given theme
+---Carry out the necessary work to load the given theme
 ---@param theme table  the theme to load
 ---@return nil
 function M.load(theme)

--- a/lua/onedarkpro/utils/variable.lua
+++ b/lua/onedarkpro/utils/variable.lua
@@ -12,7 +12,7 @@ local function replace_var(str, table)
 end
 
 
----Replace variables in a table recursivly
+---Replace variables in a table recursively
 ---@param table table the table to be replaced
 ---@param values table the values to be replaced by the replace_vars strings in the table passed in
 ---@return table


### PR DESCRIPTION
I did fix the typo "focussed".

I did add an `or` in `config.lua` to not break user's existing config.

I did also fix comment typos with https://github.com/crate-ci/typos