### PR TITLE
Improve lualine colors in inactive windows

### DIFF
--- a/lua/lualine/themes/onedarkpro.lua
+++ b/lua/lualine/themes/onedarkpro.lua
@@ -1,4 +1,5 @@
 local colors = require("onedarkpro").get_colors()
+local config = require("onedarkpro.config").config
 
 local onedarkpro = {}
 
@@ -28,10 +29,11 @@ onedarkpro.replace = {
     b = { bg = colors.fg_gutter, fg = colors.red },
 }
 
+local inactive_bg = config.options.window_unfocused_color and colors.color_column or colors.bg
 onedarkpro.inactive = {
-    a = { bg = colors.bg_statusline, fg = colors.blue },
-    b = { bg = colors.bg_statusline, fg = colors.fg_gutter, gui = "bold" },
-    c = { bg = colors.bg_statusline, fg = colors.fg_gutter },
+    a = { bg = inactive_bg, fg = colors.blue },
+    b = { bg = inactive_bg, fg = colors.fg_gutter_inactive, gui = "bold" },
+    c = { bg = inactive_bg, fg = colors.fg_gutter_inactive },
 }
 
 return onedarkpro

--- a/lua/onedarkpro/themes/onedark.lua
+++ b/lua/onedarkpro/themes/onedark.lua
@@ -39,8 +39,9 @@ local function generate(palette)
         diff_text = palette.diff_text or "#005869",
 
         -- Lualine colors
-        bg_statusline = palette.bg_statusline or color.lighten(palette.bg, 0.95),
-        fg_gutter = palette.fg_gutter or color.lighten(palette.bg, 0.70),
+        bg_statusline = palette.bg_statusline or color.darken(palette.bg, 0.85),
+        fg_gutter = palette.fg_gutter or color.lighten(palette.bg, 0.90),
+        fg_gutter_inactive = palette.fg_gutter_inactive or palette.fg,
 
         -- Virtual text
         virtual_text_error = palette.virtual_text_error or color.lighten(palette.red, 0.7),

--- a/lua/onedarkpro/themes/onedark_vivid.lua
+++ b/lua/onedarkpro/themes/onedark_vivid.lua
@@ -39,8 +39,9 @@ local function generate(palette)
         diff_text = palette.diff_text or "#005869",
 
         -- Lualine colors
-        bg_statusline = palette.bg_statusline or color.lighten(palette.bg, 0.95),
-        fg_gutter = palette.fg_gutter or color.lighten(palette.bg, 0.70),
+        bg_statusline = palette.bg_statusline or color.darken(palette.bg, 0.85),
+        fg_gutter = palette.fg_gutter or color.lighten(palette.bg, 0.90),
+        fg_gutter_inactive = palette.fg_gutter_inactive or palette.fg,
 
         -- Virtual text
         virtual_text_error = palette.virtual_text_error or color.lighten(palette.red, 0.7),

--- a/lua/onedarkpro/themes/onelight.lua
+++ b/lua/onedarkpro/themes/onelight.lua
@@ -42,6 +42,7 @@ local function generate(palette)
         -- Lualine colors
         bg_statusline = palette.bg_statusline or color.darken(palette.bg, 0.97),
         fg_gutter = palette.fg_gutter or color.darken(palette.bg, 0.90),
+        fg_gutter_inactive = palette.fg_gutter_inactive or palette.fg,
 
         -- Virtual text
         virtual_text_error = palette.virtual_text_error or color.lighten(palette.red, 0.6),


### PR DESCRIPTION
The biggest change is that the default colors for the part of the lualine status line where the git info is displayed are better (IMO).

Additionally:
1. New configurable color to give greater control of the appearance of the lualine to users
2. Correctly dim the statusline bg in inactive windows to match the bg of the editor body

(This doesn't impact the light theme much.)

Before (onedark/vivid/light)

![image](https://user-images.githubusercontent.com/524994/194925763-bb27cd77-3cd6-4281-a51e-a9cdde1ce57b.png)

![image](https://user-images.githubusercontent.com/524994/194925628-b605723d-679c-4d91-bf80-ecccbe9d24fd.png)

![image](https://user-images.githubusercontent.com/524994/194925957-1fd1aaf2-8dfa-40a8-8319-f7aed0e4cddc.png)

After

![image](https://user-images.githubusercontent.com/524994/194926110-fef11cc7-5797-4e3e-a929-2e73806dfa97.png)

![image](https://user-images.githubusercontent.com/524994/194926186-8cac04ec-93c0-4abf-bcd0-1013137c1a14.png)

![image](https://user-images.githubusercontent.com/524994/194926249-00e0a408-7225-426a-ac5e-da4f62d0eb5d.png)
