### PR TITLE
Append to winhighlight instead of overwriting it

### DIFF
--- a/lua/onedarkpro/main.lua
+++ b/lua/onedarkpro/main.lua
@@ -87,7 +87,7 @@ local function add_unfocused_window_autocmds()
         group = OneDarkPro_HighlightNC,
         callback = function()
             local highlights = vim.bo.filetype == "qf" and QuickFixNCHighlights or NCHighlights
-            vim.cmd("set winhighlight=" .. highlights)
+            vim.cmd("set winhighlight+=" .. highlights)
         end,
     })
     vim.api.nvim_create_autocmd("WinEnter", {


### PR DESCRIPTION
Small change to append to `winhighlight` when setting it for inactive windows instead of overwriting it.

This basically makes `window_unfocused_color = true` play nicer with other plugins (or user configs) that also set `winhighlight`. One example: diffview.nvim with enhanced highlights enabled. I believe I also ran into a problem with `window_unfocused_color = true` and noice.nvim, but I haven't confirmed that this change is enough to fix that issue, as I'm not generally using noice.

I _swear_ I tried this during the initial implementation and it didn't work. :dizzy_face: 