### PR TITLE
add highlight for `@storageclass.rust`

### DIFF
--- a/lua/onedarkpro/highlights/filetypes/rust.lua
+++ b/lua/onedarkpro/highlights/filetypes/rust.lua
@@ -14,6 +14,7 @@ function M.groups(theme, config)
         ["@label.rust"] = { fg = theme.palette.white },
         ["@operator.rust"] = { fg = theme.palette.fg },
         ["@parameter.rust"] = { fg = theme.palette.red, style = config.options.italic },
+        ["@storageclass.rust"] = { link = '@keyword' }
     }
 end
 

--- a/lua/onedarkpro/highlights/filetypes/rust.lua
+++ b/lua/onedarkpro/highlights/filetypes/rust.lua
@@ -14,7 +14,7 @@ function M.groups(theme, config)
         ["@label.rust"] = { fg = theme.palette.white },
         ["@operator.rust"] = { fg = theme.palette.fg },
         ["@parameter.rust"] = { fg = theme.palette.red, style = config.options.italic },
-        ["@storageclass.rust"] = { link = '@keyword' }
+        ["@storageclass.rust"] = { link = '@keyword' },
     }
 end
 


### PR DESCRIPTION
In Rust, stuff like `const` gets highlighted as `@storageclass`, which looks almost the same color as some variables. Really, it's a keyword.