### PR TITLE
Bugfix: attempt to index field 'config' (a nil value)

### DIFF
--- a/lua/onedarkpro/theme.lua
+++ b/lua/onedarkpro/theme.lua
@@ -26,7 +26,7 @@ end
 ---@param theme? string (optional)
 ---@return table
 function M.load(theme)
-    theme = get_theme(theme or require("onedarkpro.config").config.theme)
+    theme = get_theme(theme or require("onedarkpro.config").theme)
     theme = require("onedarkpro.themes." .. theme)
 
     if require("onedarkpro.override").has_override then


### PR DESCRIPTION
On the latest version of the theme, I get this error when starting neovim:

```
Error detected while processing /home/mmirus/.config/nvim/init.lua:
E5113: Error while calling lua chunk: ...ck/packer/start/onedarkpro.nvim/lua/onedarkpro/theme.
lua:29: attempt to index field 'config' (a nil value)
stack traceback:
        ...ck/packer/start/onedarkpro.nvim/lua/onedarkpro/theme.lua:29: in function 'load'
        ...ack/packer/start/onedarkpro.nvim/lua/onedarkpro/init.lua:93: in function 'get_color
s'
        /home/mmirus/.config/nvim/lua/mmirus/onedark.lua:3: in main chunk
        [C]: in function 'require'
        /home/mmirus/.config/nvim/lua/mmirus/init.lua:8: in main chunk
        [C]: in function 'require'
"lua/mmirus/packer.lua" 130L, 3583B
```

If I revert back to 550cddf05348b6d497934d2e1c27f7b8867a1796, the theme works.

This change seems to fix the bug.
