### PR TITLE
Match vscode markdown checkbox styling

### DIFF
--- a/lua/onedarkpro/highlights/filetypes/markdown.lua
+++ b/lua/onedarkpro/highlights/filetypes/markdown.lua
@@ -15,6 +15,8 @@ function M.groups(theme)
         ["@punctuation.special.markdown"] = { fg = theme.palette.red },
         ["@punctuation.delimiter.markdown_inline"] = { fg = theme.palette.orange },
         ["@text.uri.markdown_inline"] = { fg = theme.palette.purple },
+        ["@text.todo.unchecked.markdown_inline"] = { fg = theme.palette.bg, bg = theme.palette.fg },
+        ["@text.todo.checked.markdown_inline"] = { fg = theme.palette.blue },
     }
 end
 


### PR DESCRIPTION
Support for this was recently added to Treesitter.

neovim
![image](https://user-images.githubusercontent.com/524994/206587228-4d64b0e5-be48-447b-bd7b-dc39dcb5d313.png)

vscode
![image](https://user-images.githubusercontent.com/524994/206587332-2593e215-33b9-4e96-a9d8-5b8711ee84cc.png)
