### PR TITLE
Fix markdown checkbox highlights

### DIFF
--- a/lua/onedarkpro/highlights/filetypes/markdown.lua
+++ b/lua/onedarkpro/highlights/filetypes/markdown.lua
@@ -15,8 +15,8 @@ function M.groups(theme)
         ["@punctuation.special.markdown"] = { fg = theme.palette.red },
         ["@punctuation.delimiter.markdown_inline"] = { fg = theme.palette.orange },
         ["@text.uri.markdown_inline"] = { fg = theme.palette.purple },
-        ["@text.todo.unchecked.markdown_inline"] = { fg = theme.palette.bg, bg = theme.palette.fg },
-        ["@text.todo.checked.markdown_inline"] = { fg = theme.palette.blue },
+        ["@text.todo.unchecked"] = { fg = theme.palette.bg, bg = theme.palette.fg },
+        ["@text.todo.checked"] = { fg = theme.palette.blue },
     }
 end
 


### PR DESCRIPTION
https://github.com/olimorris/onedarkpro.nvim/pull/135 was broken. I added the `markdown_inline`s locally and it seemed to work, but alas it was just cached from a previous version without those.

This should be correct.
