### PR TITLE
PHP: Update highlights for type qualifiers

### DIFF
--- a/lua/onedarkpro/highlights/filetypes/php.lua
+++ b/lua/onedarkpro/highlights/filetypes/php.lua
@@ -12,6 +12,7 @@ function M.groups(theme)
         ["@function.builtin.php"] = { fg = theme.palette.cyan },
         ["@namespace.php"] = { fg = theme.palette.yellow, style = config.options.bold },
         ["@constant.builtin.php"] = { fg = theme.palette.orange },
+        ["@type.qualifier.php"] = { link = "@keyword.function.php" },
     }
 end
 


### PR DESCRIPTION
Example: `public` in `public function`

Before:

![image](https://user-images.githubusercontent.com/524994/207930235-cc9a2082-b896-46e1-b142-abccff8e9d9f.png)

After:

![image](https://user-images.githubusercontent.com/524994/207930340-f7260e6a-67a6-4e4f-9fe5-1e8db45d968b.png)
