### PR TITLE
refactor!: deprecate some options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,18 +70,17 @@ return {
 }
 ```
 
-- The colorscheme enables users to be able to turn off certain styles like `bold` and `italic`. To match to the styles from VS Code, whilst still enabling the user to apply customisations:
+- The colorscheme enables users to be able to customise styles to highlight groups such as `functions`, `variables` and `keywords` (as per the [README](https://github.com/olimorris/onedarkpro.nvim#configuring-styles)). This allows users to match to the styles from VS Code whilst still enabling customisations:
 
 ```lua
 local config = require("onedarkpro.config").config
 
 return {
-    ["@function.ruby"] = { fg = theme.palette.blue, style = config.options.bold },
+    ["@function.ruby"] = { fg = theme.palette.blue, style = config.styles.functions },
 }
 ```
-> **Note:** Possible options for `config.options.*` are `bold`, `italic`, `bold_italic`, `undercurl`, `underline`, `none`
 
-- For highlight groups that do not have any styling in VS Code, you should allow for the user to apply their own custom styles (as per the [README](https://github.com/olimorris/onedarkpro.nvim#configuring-styles))
+- For highlight groups that do not have any styling in VS Code, you should allow for the user to apply their own custom styles
 - This would fallback to `style = config.styles.functions` for a highlight group such as `["@function.ruby]`
 
 ### Final configuration
@@ -138,7 +137,7 @@ local config = require("onedarkpro.config").config
 return {
     AerialClass = {
         fg = theme.palette.purple,
-        style = config.options.bold_italic,
+        style = "bold,italic"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -188,11 +188,6 @@ require("onedarkpro").setup({
     virtual_text = "NONE", -- Style that is applied to virtual text
   },
   options = {
-    bold = true, -- Use bold styles?
-    italic = true, -- Use italic styles?
-    underline = true, -- Use underline styles?
-    undercurl = true, -- Use undercurl styles?
-
     cursorline = false, -- Use cursorline highlighting?
     transparency = false, -- Use a transparent background?
     terminal_colors = true, -- Use the theme's colors for Neovim's :terminal?
@@ -446,19 +441,6 @@ styles = {
 > :bangbang: See the [Neovim help](<https://neovim.io/doc/user/api.html#nvim_set_hl()>) for a full list of styles
 
 ### Configuring options
-
-#### Formatting
-
-Alongside styles, the theme enables additional formatting options; often used in combination with filetype highlighting. These can be turned on or off:
-
-```lua
-options = {
-  bold = true,
-  italic = false,
-  underline = false,
-  undercurl = true
-}
-```
 
 #### Transparency
 

--- a/lua/onedarkpro/config.lua
+++ b/lua/onedarkpro/config.lua
@@ -66,6 +66,7 @@ local defaults = {
     highlights = {}, -- Add/override highlights
     styles = {
         types = "NONE", -- Style that is applied to types
+        methods = "NONE", -- Style that is applied to methods
         numbers = "NONE", -- Style that is applied to numbers
         strings = "NONE", -- Style that is applied to strings
         comments = "NONE", -- Style that is applied to comments
@@ -74,15 +75,11 @@ local defaults = {
         functions = "NONE", -- Style that is applied to functions
         operators = "NONE", -- Style that is applied to operators
         variables = "NONE", -- Style that is applied to variables
+        parameters = "NONE", -- Style that is applied to operators
         conditionals = "NONE", -- Style that is applied to conditionals
         virtual_text = "NONE", -- Style that is applied to virtual text
     },
     options = {
-        bold = true, -- Use bold styles?
-        italic = true, -- Use italic styles?
-        underline = true, -- Use underline styles?
-        undercurl = true, -- Use undercurl styles?
-
         cursorline = false, -- Use cursorline highlighting?
         transparency = false, -- Use a transparent background?
         terminal_colors = true, -- Use the theme's colors for Neovim's :terminal?
@@ -91,27 +88,6 @@ local defaults = {
 }
 
 M.config = vim.deepcopy(defaults)
-
----Set the theme's options
----@param opts table
----@return table
-local function set_options(opts)
-    if opts.cursorline then vim.wo.cursorline = true end
-
-    return {
-        none = "NONE",
-        bold = opts.bold and "bold" or "NONE",
-        italic = opts.italic and "italic" or "NONE",
-        undercurl = opts.undercurl and "undercurl" or "NONE",
-        underline = opts.underline and "underline" or "NONE",
-        undercurl_underline = (opts.undercurl and opts.underline) and "underline,undercurl" or "NONE",
-        bold_italic = (opts.bold and opts.italic) and "bold,italic" or "NONE",
-        cursorline = opts.cursorline,
-        transparency = opts.transparency,
-        terminal_colors = opts.terminal_colors,
-        highlight_inactive_windows = opts.highlight_inactive_windows,
-    }
-end
 
 ---Determine the filetypes or plugins that should be loaded
 ---@param files table
@@ -146,8 +122,8 @@ function M.setup(opts)
     opts = opts or {}
 
     M.config = util.deep_extend(M.config, opts)
-    M.config.options = set_options(M.config.options)
 
+    if M.config.options.cursorline then vim.wo.cursorline = true end
     if opts and opts.filetypes then M.config.filetypes = load_files(M.config.filetypes, opts.filetypes) end
     if opts and opts.plugins then M.config.plugins = load_files(M.config.plugins, opts.plugins) end
 

--- a/lua/onedarkpro/highlights/filetypes/javascript.lua
+++ b/lua/onedarkpro/highlights/filetypes/javascript.lua
@@ -10,11 +10,11 @@ function M.groups(theme)
         ["@constructor.javascript"] = { fg = theme.palette.yellow },
         ["@keyword.javascript"] = { fg = theme.palette.purple, style = config.styles.keywords },
         ["@keyword.return.javascript"] = { fg = theme.palette.purple },
-        ["@method.javascript"] = { fg = theme.palette.blue, style = config.options.bold },
+        ["@method.javascript"] = { fg = theme.palette.blue, style = config.styles.methods },
         ["@method.call.javascript"] = { link = "@method.javascript" },
         ["@punctuation.bracket.javascript"] = { fg = theme.palette.yellow },
-        ["@variable.javascript"] = { fg = theme.palette.red, style = config.options.italic },
-        ["@variable.builtin.javascript"] = { fg = theme.palette.yellow, style = config.options.italic },
+        ["@variable.javascript"] = { fg = theme.palette.red, style = config.styles.variables },
+        ["@variable.builtin.javascript"] = { fg = theme.palette.yellow, style = config.styles.variables },
     }
 end
 

--- a/lua/onedarkpro/highlights/filetypes/lua.lua
+++ b/lua/onedarkpro/highlights/filetypes/lua.lua
@@ -7,15 +7,15 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@comment.lua"] = { fg = theme.palette.comment, style = config.options.italic },
-        ["@function.builtin.lua"] = { fg = theme.palette.cyan, style = config.options.bold },
-        ["@function.call.lua"] = { fg = theme.palette.blue, style = config.options.bold },
+        ["@comment.lua"] = { fg = theme.palette.comment, style = config.styles.comments },
+        ["@function.builtin.lua"] = { fg = theme.palette.cyan, style = config.styles.functions },
+        ["@function.call.lua"] = { fg = theme.palette.blue, style = config.styles.functions },
         ["@field.lua"] = { fg = theme.palette.fg },
         ["@keyword.lua"] = { fg = theme.palette.purple, style = config.styles.keywords },
         ["@keyword.operator.lua"] = { fg = theme.palette.fg },
-        ["@method.lua"] = { fg = theme.palette.blue, style = config.options.bold },
+        ["@method.lua"] = { fg = theme.palette.blue, style = config.styles.methods },
         ["@operator.lua"] = { fg = theme.palette.fg, style = config.styles.operators },
-        ["@parameter.lua"] = { fg = theme.palette.fg, style = config.options.italic },
+        ["@parameter.lua"] = { fg = theme.palette.fg, style = config.styles.parameters },
         ["@punctuation.bracket.lua"] = { fg = theme.palette.orange },
     }
 end

--- a/lua/onedarkpro/highlights/filetypes/markdown.lua
+++ b/lua/onedarkpro/highlights/filetypes/markdown.lua
@@ -9,8 +9,8 @@ function M.groups(theme)
     return {
         ["@text.literal.markdown_inline"] = { fg = theme.palette.green },
         ["@text.reference.markdown_inline"] = { fg = theme.palette.blue },
-        ["@text.strong.markdown_inline"] = { fg = theme.palette.orange, style = config.options.bold },
-        ["@text.title.markdown"] = { fg = theme.palette.red, style = config.options.bold },
+        ["@text.strong.markdown_inline"] = { fg = theme.palette.orange, style = "bold" },
+        ["@text.title.markdown"] = { fg = theme.palette.red, style = "bold" },
         ["@parameter.markdown_inline"] = { fg = theme.palette.fg },
         ["@punctuation.special.markdown"] = { fg = theme.palette.red },
         ["@punctuation.delimiter.markdown_inline"] = { fg = theme.palette.orange },

--- a/lua/onedarkpro/highlights/filetypes/php.lua
+++ b/lua/onedarkpro/highlights/filetypes/php.lua
@@ -7,10 +7,10 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@method.php"] = { fg = theme.palette.blue, style = config.options.bold },
+        ["@method.php"] = { fg = theme.palette.blue, style = config.styles.methods },
         ["@method.call.php"] = { link = "@method.php" },
         ["@function.builtin.php"] = { fg = theme.palette.cyan },
-        ["@namespace.php"] = { fg = theme.palette.yellow, style = config.options.bold },
+        ["@namespace.php"] = { fg = theme.palette.yellow, style = config.styles.keywords },
         ["@constant.builtin.php"] = { fg = theme.palette.orange },
         ["@type.qualifier.php"] = { link = "@keyword.function.php" },
     }

--- a/lua/onedarkpro/highlights/filetypes/python.lua
+++ b/lua/onedarkpro/highlights/filetypes/python.lua
@@ -7,10 +7,10 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@constructor.python"] = { fg = theme.palette.cyan, style = config.options.bold },
-        ["@conditional.python"] = { fg = theme.palette.purple, style = config.options.italic },
-        ["@method.call.python"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@variable.builtin.python"] = { fg = theme.palette.yellow, style = config.options.italic },
+        ["@constructor.python"] = { fg = theme.palette.cyan },
+        ["@conditional.python"] = { fg = theme.palette.purple, style = config.styles.conditionals },
+        ["@method.call.python"] = { fg = theme.palette.blue, style = config.styles.methods },
+        ["@variable.builtin.python"] = { fg = theme.palette.yellow, style = config.styles.variables },
     }
 end
 

--- a/lua/onedarkpro/highlights/filetypes/ruby.lua
+++ b/lua/onedarkpro/highlights/filetypes/ruby.lua
@@ -7,11 +7,11 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@function.ruby"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@function.call.ruby"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@include.ruby"] = { fg = theme.palette.blue, style = config.options.italic },
+        ["@function.ruby"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@function.call.ruby"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@include.ruby"] = { fg = theme.palette.blue, style = config.styles.keywords },
         ["@label.ruby"] = { fg = theme.palette.red },
-        ["@parameter.ruby"] = { fg = theme.palette.fg, style = config.options.italic },
+        ["@parameter.ruby"] = { fg = theme.palette.fg, style = config.styles.parameters },
         ["@punctuation.bracket.ruby"] = { fg = theme.palette.yellow },
         ["@symbol.ruby"] = { fg = theme.palette.cyan },
     }

--- a/lua/onedarkpro/highlights/filetypes/rust.lua
+++ b/lua/onedarkpro/highlights/filetypes/rust.lua
@@ -14,7 +14,7 @@ function M.groups(theme)
         ["@keyword.rust"] = { fg = theme.palette.purple },
         ["@label.rust"] = { fg = theme.palette.white },
         ["@operator.rust"] = { fg = theme.palette.fg },
-        ["@parameter.rust"] = { fg = theme.palette.red, style = config.options.italic },
+        ["@parameter.rust"] = { fg = theme.palette.red, style = config.styles.parameters },
         ["@storageclass.rust"] = { link = "@keyword" },
     }
 end

--- a/lua/onedarkpro/highlights/filetypes/typescript.lua
+++ b/lua/onedarkpro/highlights/filetypes/typescript.lua
@@ -7,11 +7,11 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@function.typescript"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@function.call.typescript"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@method.typescript"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@method.call.typescript"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@parameter.typescript"] = { fg = theme.palette.red, style = config.options.italic },
+        ["@function.typescript"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@function.call.typescript"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@method.typescript"] = { fg = theme.palette.blue, style = config.styles.methods },
+        ["@method.call.typescript"] = { fg = theme.palette.blue, style = config.styles.methods },
+        ["@parameter.typescript"] = { fg = theme.palette.red, style = config.styles.parameters },
         ["@punctuation.bracket.typescript"] = { fg = theme.palette.orange },
         ["@variable.typescript"] = { fg = theme.palette.red },
     }

--- a/lua/onedarkpro/highlights/filetypes/typescriptreact.lua
+++ b/lua/onedarkpro/highlights/filetypes/typescriptreact.lua
@@ -7,11 +7,11 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@function.tsx"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@function.call.tsx"] = { fg = theme.palette.blue, style = config.options.bold },
-        ["@parameter.tsx"] = { fg = theme.palette.red, style = config.options.italic },
+        ["@function.tsx"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@function.call.tsx"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@parameter.tsx"] = { fg = theme.palette.red, style = config.styles.parameters },
         ["@punctuation.bracket.tsx"] = { fg = theme.palette.orange },
-        ["@tag.attribute.tsx"] = { fg = theme.palette.orange, style = config.options.italic },
+        ["@tag.attribute.tsx"] = { fg = theme.palette.orange },
         ["@type.builtin.tsx"] = { fg = theme.palette.purple },
     }
 end

--- a/lua/onedarkpro/highlights/plugins/native_lsp.lua
+++ b/lua/onedarkpro/highlights/plugins/native_lsp.lua
@@ -18,10 +18,10 @@ function M.groups(theme)
         DiagnosticSignInfo = { fg = theme.palette.blue },
         DiagnosticSignHint = { fg = theme.palette.cyan },
 
-        DiagnosticUnderlineError = { fg = theme.palette.red, style = config.options.undercurl },
-        DiagnosticUnderlineWarn = { fg = theme.palette.yellow, style = config.options.undercurl },
-        DiagnosticUnderlineInfo = { fg = theme.palette.blue, style = config.options.undercurl },
-        DiagnosticUnderlineHint = { fg = theme.palette.cyan, style = config.options.undercurl },
+        DiagnosticUnderlineError = { fg = theme.palette.red, style = "undercurl" },
+        DiagnosticUnderlineWarn = { fg = theme.palette.yellow, style = "undercurl" },
+        DiagnosticUnderlineInfo = { fg = theme.palette.blue, style = "undercurl" },
+        DiagnosticUnderlineHint = { fg = theme.palette.cyan, style = "undercurl" },
 
         DiagnosticVirtualTextError = { fg = theme.generated.virtual_text_error, style = config.styles.virtual_text },
         DiagnosticVirtualTextWarn = { fg = theme.generated.virtual_text_warning, style = config.styles.virtual_text },

--- a/lua/onedarkpro/highlights/plugins/nvim_bqf.lua
+++ b/lua/onedarkpro/highlights/plugins/nvim_bqf.lua
@@ -9,7 +9,7 @@ function M.groups(theme)
     return {
         BqfPreviewBorder = { fg = theme.palette.gray },
         BqfPreviewRange = { fg = theme.palette.green },
-        BqfSign = { fg = theme.palette.purple, style = config.options.bold },
+        BqfSign = { fg = theme.palette.purple, style = "bold" },
     }
 end
 

--- a/lua/onedarkpro/highlights/plugins/treesitter.lua
+++ b/lua/onedarkpro/highlights/plugins/treesitter.lua
@@ -95,7 +95,7 @@ function M.groups(theme)
         ["@text.math"] = { fg = theme.palette.fg }, -- math environments (e.g. `$ ... $` in LaTeX)
         ["@text.environment"] = { link = "Macro" }, -- text environments of markup languages
         ["@text.environment.name"] = { link = "Type" }, -- text indicating the type of an environment
-        ["@text.reference"] = { fg = theme.palette.fg, style = config.options.bold }, -- text references, footnotes, citations, etc.
+        ["@text.reference"] = { fg = theme.palette.fg }, -- text references, footnotes, citations, etc.
 
         --["@text.todo] -- todo notes
         ["@text.todo.checked"] = { fg = theme.palette.blue },

--- a/tests/basic_spec.lua
+++ b/tests/basic_spec.lua
@@ -34,6 +34,6 @@ describe("Using the colorscheme without calling setup,", function()
 
     it("it should be able to load filetypes", function()
         local output = vim.api.nvim_exec("hi @variable.javascript", true)
-        assert.equals("@variable.javascript xxx cterm=italic gui=italic guifg=#e06c75", output)
+        assert.equals("@variable.javascript xxx guifg=#e06c75", output)
     end)
 end)


### PR DESCRIPTION
From the beginning, the colorscheme has applied an opinionated number of `bold` and `italic` styles to highlight groups. These have been configured through the `config.options` table alongside the `config.styles` tables. As one might expect, both of these tread closely to one another and it is often difficult to determine whether it should be an option or a style.

The implementation of the `options` relies on checking the user config for `config.options.bold` being true and then applying a `bold` style to any highlight groups which reference `config.options.bold`. It's slightly cumbersome and adds an additional layer of setup to the colorscheme's configuration.

In this PR, we move away from `options` completely and instead everything is controlled via `styles` with some new additions for `methods` and `parameters`.

I don't take deprecations lightly however this makes the creation of filetype highlight groups and planned new features a lot easier.