### PR TITLE
feat(compile): remove table overhead for better performance

### DIFF
--- a/lua/onedarkpro/lib/hash.lua
+++ b/lua/onedarkpro/lib/hash.lua
@@ -9,21 +9,20 @@ local bitop = bit or bit32 or require("onedarkpro.lib.native_bit")
 ---@return number
 local function djb2(s)
     local h = 5381
-    local t = { string.byte(s, 1, #s) }
-    for i = 1, #t do
-        h = bitop.lshift(h, 5) + t[i] -- h * 33 + c
+    for i = 1, #s do
+        h = bitop.lshift(h, 5) + string.byte(s, i) -- h * 33 + c
     end
     return h
 end
 
--- Reference: https://github.com/catppuccin/nvim/blob/151b5f6aa74f08a707a7862519bdc38bb2b9f505/lua/catppuccin/lib/hashing.lua
+-- Reference: https://github.com/catppuccin/nvim/blob/60f8f40df0db92b5715642b3ea7074380c4b7995/lua/catppuccin/lib/hashing.lua
 ---@param x table|function|number|string
 ---@return string|number
 local function hash(x)
     local t = type(x)
     if t == "table" then
         local h = 0
-        for k, v in pairs(x) do
+        for k, v in next, x do
             h = bitop.bxor(h, djb2(k .. hash(v)))
         end
         return h


### PR DESCRIPTION
- `{ string.byte }` is only faster if we re-use the table a lot
- The definition for `pairs` is `function pairs(t) return next, t, nil end` so we have another small optimization to use `next, t` instead of `pairs(t)` 

Benchmark was done on both `main` and `perf` branch

| branch | time (ms) |
| ------ | ---- |
| main | 0.554543993 |                                                                                  
| perf | 0.003715965 |

Benchmark code:

```lua
local O = require("onedarkpro.config").config
local hash = require "onedarkpro.lib.hash"
local iter = 1000
local start = vim.loop.hrtime()
for _ = 1, iter do
	hash(O)
end
print((vim.loop.hrtime() - start) / iter / 1000000)
```

Ported from https://github.com/catppuccin/nvim/pull/410
