### PR TITLE
fix: djb2 hashing

### DIFF
--- a/lua/onedarkpro/lib/hash.lua
+++ b/lua/onedarkpro/lib/hash.lua
@@ -10,12 +10,12 @@ local bitop = bit or bit32 or require("onedarkpro.lib.native_bit")
 local function djb2(s)
     local h = 5381
     for i = 1, #s do
-        h = bitop.lshift(h, 5) + string.byte(s, i) -- h * 33 + c
+        h = bitop.lshift(h, 5) + h + string.byte(s, i) -- h * 33 + c
     end
     return h
 end
 
--- Reference: https://github.com/catppuccin/nvim/blob/60f8f40df0db92b5715642b3ea7074380c4b7995/lua/catppuccin/lib/hashing.lua
+-- Reference: https://github.com/catppuccin/nvim/blob/bad9c23f12944683cd11484d9570560849efc101/lua/catppuccin/lib/hashing.lua
 ---@param x table|function|number|string
 ---@return string|number
 local function hash(x)

--- a/tests/cache_spec.lua
+++ b/tests/cache_spec.lua
@@ -44,7 +44,7 @@ describe("Using the cache", function()
     end)
 
     it("the SAME table should always return the SAME hash", function()
-        assert.equals(-1727766954, hash)
+        assert.equals(-215055643, hash)
     end)
 
     it("a MODIFIED table should return a DIFFERENT hash", function()


### PR DESCRIPTION
`h * 33 + c = ((h * 32) + h) + c = ((h << 5) + h) + c` not `(h << 5) + c`

This was a silly mistake made when I fixed the arm64 overflow issue by replacing multiplication with bit shift

Without this fix the collision is insanely high, `custom_highlight` has the same hash as `ustom_highlight`