### PR TITLE
added missing commas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ Or, all of the filetypes can be disabled with a select few enabled:
 ```lua
 require("onedarkpro").setup({
   filetypes = {
-    all = false
-    markdown = true
+    all = false,
+    markdown = true,
     ruby = true,
   }
 })
@@ -439,7 +439,7 @@ Or, all of the plugins can be disabled with a select few enabled:
 ```lua
 require("onedarkpro").setup({
   plugins = {
-    all = false
+    all = false,
     nvim_lsp = true,
     treesitter = true
   }


### PR DESCRIPTION
When using the example in the README, I got a syntax error.

This PR adds missing commas in the README to fix these errors.