### PR TITLE
Updated after/queries/python/highlights.scm

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -7,8 +7,8 @@
 ((function_definition name: (identifier) @odp.base_constructor)
 (#any-of? @odp.base_constructor "__new__" "__init__"))
 
-(assignment right: (call (identifier) @odp.constructor)
-(#any-of? @odp.constructor "range" "list" "tuple" "dict" "set" "frozenset" "str" "int" "float" "complex" "bytes" "bytearray" "memoryview"))
+(call function: (identifier) @odp.constructor
+(#any-of? @odp.constructor "range" "list" "tuple" "dict" "set" "frozenset" "str" "int" "float" "complex" "bool" "bytes" "bytearray" "memoryview"))
 
 ((identifier) @odp.keyword (#vim-match? @odp.keyword "^(kwargs|self)$"))
 (class_definition "class" @odp.keyword.class)


### PR DESCRIPTION
In the task of tagging `@odp.constructor` onto various python built-in types, instead of querying "assignment right" (which handles only the specific case of assignment statements) we can query "call function." The latter takes care of all cases including built-in constructor calls in for_statements, while_statements, if_statements, argument lists, and even basic parenthesized expression.

Special case only:
```
(assignment right: (call (identifier) @odp.constructor)
(#any-of? @odp.constructor "range" "list" "tuple" "dict" "set" "frozenset" "str" "int" "float" "complex" "bytes" "bytearray" "memoryview")) 
```
Takes care of all cases:
```
(call function: (identifier) @odp.constructor
(#any-of? @odp.constructor "range" "list" "tuple" "dict" "set" "frozenset" "str" "int" "float" "complex" "bool" "bytes" "bytearray" "memoryview")) 
```

**Before:** 
![Before](https://user-images.githubusercontent.com/69449791/225791074-2a4617cb-b5d5-457b-a1e3-d0d13dff9ebd.png)

**After:**
![After](https://user-images.githubusercontent.com/69449791/225791377-a17b4140-fa6a-406d-83de-8d178f46db01.png)
