### PR TITLE
feat: 'go' support improved

### DIFF
--- a/lua/onedarkpro/highlights/filetypes/go.lua
+++ b/lua/onedarkpro/highlights/filetypes/go.lua
@@ -8,11 +8,16 @@ function M.groups(theme)
 
     return {
         ["@constant.go"] = { fg = theme.palette.red },
-        ["@function.call.go"] = { fg = theme.palette.cyan },
-        ["@method.call.go"] = { fg = theme.palette.cyan },
-        ["@operator.go"] = { fg = theme.palette.yellow },
-        ["@type.go"] = { fg = theme.palette.fg },
+        ["@function.call.go"] = { fg = theme.palette.blue },
+        ["@method.call.go"] = { fg = theme.palette.blue },
+        ["@function.builtin.go"] = { fg = theme.palette.cyan },
+        ["@operator.go"] = { fg = theme.palette.cyan },
+        ["@type.go"] = { fg = theme.palette.yellow },
         ["@type.builtin.go"] = { fg = theme.palette.purple },
+        ["@field.go"] = { fg = theme.palette.red },
+        ["@property.go"] = { fg = theme.palette.red },
+        ["@variable.go"] = { fg = theme.palette.red },
+        ["@parameter.go"] = { fg = theme.palette.red },
     }
 end
 

--- a/lua/onedarkpro/highlights/filetypes/go.lua
+++ b/lua/onedarkpro/highlights/filetypes/go.lua
@@ -7,17 +7,17 @@ function M.groups(theme)
     local config = require("onedarkpro.config").config
 
     return {
-        ["@constant.go"] = { fg = theme.palette.red },
-        ["@function.call.go"] = { fg = theme.palette.blue },
-        ["@method.call.go"] = { fg = theme.palette.blue },
-        ["@function.builtin.go"] = { fg = theme.palette.cyan },
-        ["@operator.go"] = { fg = theme.palette.cyan },
-        ["@type.go"] = { fg = theme.palette.yellow },
-        ["@type.builtin.go"] = { fg = theme.palette.purple },
-        ["@field.go"] = { fg = theme.palette.red },
-        ["@property.go"] = { fg = theme.palette.red },
-        ["@variable.go"] = { fg = theme.palette.red },
-        ["@parameter.go"] = { fg = theme.palette.red },
+        ["@constant.go"] = { fg = theme.palette.red, style = config.styles.constant },
+        ["@function.call.go"] = { fg = theme.palette.blue, style = config.styles.functions },
+        ["@method.call.go"] = { fg = theme.palette.blue, style = config.styles.methods },
+        ["@function.builtin.go"] = { fg = theme.palette.cyan, style = config.styles.functions },
+        ["@operator.go"] = { fg = theme.palette.cyan, style = config.styles.operators },
+        ["@type.go"] = { fg = theme.palette.yellow, style = config.styles.types },
+        ["@type.builtin.go"] = { fg = theme.palette.purple, style = config.styles.types },
+        ["@field.go"] = { fg = theme.palette.red, style = config.styles.variables },
+        ["@property.go"] = { fg = theme.palette.red, style = config.styles.variables },
+        ["@variable.go"] = { fg = theme.palette.red, style = config.styles.variables },
+        ["@parameter.go"] = { fg = theme.palette.red, style = config.styles.parameters },
     }
 end
 


### PR DESCRIPTION
Hello. Here is the PR according to [this](https://github.com/olimorris/onedarkpro.nvim/commit/434b67beced0b518804712ab04b8cf4bcf1aed7d#commitcomment-109954231). You can see screenshots below
This is how `go`  looks in VsCode
![image](https://user-images.githubusercontent.com/40483227/233625495-03acf8bf-970a-4de7-97a5-47c0f1c46cfb.png)

This is how `go` looks before this commit in neovim
![image](https://user-images.githubusercontent.com/40483227/233625697-18928781-d443-4b2a-a772-5fcbdeaebd90.png)

And this is how `go` looks after this commit in neovim
![image](https://user-images.githubusercontent.com/40483227/233625770-beaece68-fca7-412f-9c83-8a6b68d3bef2.png)

