### PR TITLE
Update highlights.scm for Python

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -3,7 +3,7 @@
 (dictionary_splat_pattern ("**" @odp.operator.splat))
 
 (import_from_statement) "from" @odp.import_from
-((dotted_name) @odp.import_module (#set! "priority" 126))
+(import_statement name: (dotted_name (identifier) @odp.import_module))
 
 ((function_definition name: (identifier) @odp.base_constructor)
 (#any-of? @odp.base_constructor "__new__" "__init__"))


### PR DESCRIPTION
Eliminate awkward 126 priority value for `@odp.import_module`, which makes for more sensible after queries.