### PR TITLE
chore: Update python highlights.scm

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -2,7 +2,10 @@
 (list_splat_pattern ("*" @odp.operator.splat))
 (dictionary_splat_pattern ("**" @odp.operator.splat))
 
-((dotted_name) @odp.import_module (#set! "priority" 126))
+(import_statement name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))
+(import_from_statement name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))
+(import_from_statement module_name: (relative_import (dotted_name (identifier) @odp.import_module (#set! "priority" 126))))
+(import_from_statement module_name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))
 
 ((function_definition name: (identifier) @odp.base_constructor)
 (#any-of? @odp.base_constructor "__new__" "__init__"))


### PR DESCRIPTION
Achieves the same effect as the previous approach, but prevents the punctuation mark `.`  in `import` statements from being assigned the `@odp.import_module` group.

The original approach:

https://github.com/olimorris/onedarkpro.nvim/assets/69449791/a56fc7ba-bca7-47d6-906c-744fbc69216d


With this pull request:

https://github.com/olimorris/onedarkpro.nvim/assets/69449791/c12d6869-87d5-446f-9014-89261d5ee1bc

