### PR TITLE
feat: Add after queries for Go to ensure consistent syntax highlighting

### DIFF
--- a/after/queries/go/highlights.scm
+++ b/after/queries/go/highlights.scm
@@ -1,0 +1,3 @@
+; extends
+(import_declaration (import_spec path: (interpreted_string_literal) @odp.import_module))
+(import_declaration (import_spec_list (import_spec path: (interpreted_string_literal) @odp.import_module)))


### PR DESCRIPTION
**The Problem:**
With the defaults, the use of `gopls`'s semantic tokens and treesitter tokens inevitably leads to inconsistent syntax highlighting 

![2023-07-23-18-07-40](https://github.com/olimorris/onedarkpro.nvim/assets/69449791/2ce1e5ae-7e94-49c7-aef2-c9414a9042ad)

**The Cause:**
For such import statements, `gopls` only assigns semantic tokens to the package name (the last component of the import path) instead of the entire import path.
![2023-07-23-18-14-17](https://github.com/olimorris/onedarkpro.nvim/assets/69449791/7ab068d2-2c9b-4698-a8aa-64fd652647aa)

![2023-07-23-18-15-55](https://github.com/olimorris/onedarkpro.nvim/assets/69449791/a210cea2-8e9a-4447-8a80-941ee58251d2)

This inevitably leads to inconsistent highlighting if the user sets different colors for `@string.go` and `@lsp.type.namespace.go`

**The Solution:**
What this PR does is that it uses treesitter's after queries to capture the entire import path (not just the package name). This allows the theme to treat the entire import path as a single entity under the `@odp.import_module` highlight group. That way, it is possible for users to create consistent highlighting for Go import statements; e.g.: by assigning the same formatting to `@odp.import_module` and `@lsp.type.namespace.go` highlight groups. 

The choice of `@odp.import_module` is not arbitrary; the highlight group name was chosen to ensure consistency with the after queries for other languages provided by this theme. 

**Without this PR:**

https://github.com/olimorris/onedarkpro.nvim/assets/69449791/5a71d993-6f6d-4537-a99d-fa7823a6118d

**With this PR:**

https://github.com/olimorris/onedarkpro.nvim/assets/69449791/6675df0f-46a7-401f-81ba-9441d1652e9d


