### PR TITLE
feat(plugin): support rainbow_delimiters

### DIFF
--- a/lua/onedarkpro/config.lua
+++ b/lua/onedarkpro/config.lua
@@ -76,6 +76,7 @@ local defaults = {
         op_nvim = true,
         packer = true,
         polygot = true,
+        rainbow_delimiters = true,
         startify = true,
         telescope = true,
         toggleterm = true,

--- a/lua/onedarkpro/highlights/plugins/rainbow_delimiters.lua
+++ b/lua/onedarkpro/highlights/plugins/rainbow_delimiters.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+---Get the highlight groups for the plugin
+---@param theme table
+---@return table
+function M.groups(theme)
+    return {
+        RainbowDelimiterRed = { fg = theme.palette.red },
+        RainbowDelimiterYellow = { fg = theme.palette.yellow },
+        RainbowDelimiterBlue = { fg = theme.palette.blue },
+        RainbowDelimiterOrange = { fg = theme.palette.orange },
+        RainbowDelimiterGreen = { fg = theme.palette.green },
+        RainbowDelimiterViolet = { fg = theme.palette.purple },
+        RainbowDelimiterCyan = { fg = theme.palette.cyan },
+    }
+end
+
+return M


### PR DESCRIPTION
[HiPnish/nvim_ts_rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2) deprecated and migrate to [HiPnish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim)

Preview:
<img width="500" alt="image" src="https://github.com/olimorris/onedarkpro.nvim/assets/16725418/b9afac36-9704-499c-a9f6-8f112b662782">
