### PR TITLE
fix: Match C source highlighting to VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ require("onedarkpro").setup({
     virtual_text = "NONE", -- Style that is applied to virtual text
   },
   filetypes = { -- Override which filetype highlight groups are loaded
+    c = true,
     comment = true,
     go = true,
     html = true,

--- a/examples/c.c
+++ b/examples/c.c
@@ -1,0 +1,36 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define HELLO_WORLD "hello world"
+
+#define LOG(...) printf(__VA_ARGS__)
+
+typedef int myint_t;
+
+struct hello {
+    const char *world;
+    uint64_t fd;
+    struct hello *ptr;
+};
+
+/*
+ * Hello world
+ */
+int
+main(int argc, const char **argv)
+{
+    // Hello world
+    static const int rc = 0;
+
+hello:
+    printf("%s: %p", HELLO_WORLD, NULL);
+    if (true) {
+        return rc;
+    } else {
+        return 1;
+    }
+
+    goto hello;
+}

--- a/lua/onedarkpro/config.lua
+++ b/lua/onedarkpro/config.lua
@@ -26,6 +26,7 @@ local defaults = {
         virtual_text = "NONE", -- Style that is applied to virtual text
     },
     filetypes = { -- Enable/disable specific plugins
+        c = true,
         comment = true,
         go = true,
         html = true,

--- a/lua/onedarkpro/highlights/filetypes/c.lua
+++ b/lua/onedarkpro/highlights/filetypes/c.lua
@@ -1,0 +1,28 @@
+local M = {}
+
+---Get the highlight groups for the filetype
+---@param theme table
+---@return table
+function M.groups(theme)
+    local config = require("onedarkpro.config").config
+
+    return {
+        -- Support for printf format characters
+        ["@character.printf"] = { fg = theme.palette.orange },
+
+        ["@constant.c"] = { fg = theme.palette.yellow },
+        ["@constant.builtin.c"] = { fg = theme.palette.yellow },
+        ["@function.builtin.c"] = { fg = theme.palette.cyan },
+        ["@label.c"] = { fg = theme.palette.red },
+        ["@type.builtin.c"] = { fg = theme.palette.purple },
+        ["@type.qualifier.c"] = { fg = theme.palette.purple },
+        ["@variable.parameter.c"] = { fg = theme.palette.red, style = config.styles.parameters },
+
+        -- LSP Semantic Tokens
+        ["@lsp.type.macro.c"] = { fg = theme.palette.orange, style = config.styles.constants },
+        ["@lsp.typemod.function.defaultLibrary.c"] = { fg = theme.palette.cyan, style = config.styles.functions },
+        ["@lsp.typemod.variable.readonly.c"] = { fg = theme.palette.yellow, style = config.styles.variable },
+    }
+end
+
+return M


### PR DESCRIPTION
The theme was missing quite a few things to make it match VSCode.

VSCode:
![image](https://github.com/olimorris/onedarkpro.nvim/assets/11936772/b46889e0-ca7a-4d7a-8530-9c44997bae8d)

Neovim:
![image](https://github.com/olimorris/onedarkpro.nvim/assets/11936772/9d915115-9629-4e0b-9e3c-8d6e0b663114)

I can't do anything about the `LOG` line just yet. The tree-sitter grammar isn't detailed enough and clangd doesn't seems to provide good tokens here.