### PR TITLE
Added background highlight to cursor for nvim tree

### DIFF
--- a/lua/onedarkpro/highlights/plugins/nvim_tree.lua
+++ b/lua/onedarkpro/highlights/plugins/nvim_tree.lua
@@ -23,6 +23,7 @@ function M.groups(theme)
         -- NvimTreeImageFile = {},
         NvimTreeMarkdownFile = { fg = theme.palette.red },
         NvimTreeIndentMarker = { fg = theme.palette.gray },
+        NvimTreeCursorLine = { bg = theme.palette.gray },
 
         NvimTreeLicenseIcon = { fg = theme.palette.yellow },
         NvimTreeYamlIcon = { fg = theme.palette.yellow },


### PR DESCRIPTION
Hello, I noticed that in the original nvim tree there is a background highlight for the line that your cursor is on:
![image](https://github.com/user-attachments/assets/a62faedb-36ab-4d4c-85b3-e80ca83ce2ee)

I've noticed it in other themes as well but it seems as though it isn't appearing in this theme currently, so I added it in using the `palette.grey` value, here is the before and after:
![nvim_tree_before_and_after](https://github.com/user-attachments/assets/09c82c32-f68a-4fc1-9425-ebe3791ae734)

I used `palette.grey` to try and stick with convention, but if we want some other colour then I'm happy for that too

I was going to just add it for my own config, but since it appears to be the default for nvim-tree and a lot of the themes that interact with nvim-tree I thought I should submit a PR in case this is desirable as a default

Thanks!