### PR TITLE
feat: support mini.icons and mini.diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ require("onedarkpro").setup({
     lsp_semantic_tokens = true,
     marks = true,
     mini_indentscope = true,
+    mini_diff = true,
+    mini_icons = true,
     neotest = true,
     neo_tree = true,
     nvim_cmp = true,
@@ -388,7 +390,7 @@ require("onedarkpro").setup({
 ### Configuring styles
 
 > [!NOTE]
-> For a list of available styles, please refer to the [Neovim documentation](https://neovim.io/doc/user/api.html#nvim_set_hl())
+> For a list of available styles, please refer to the [Neovim documentation](<https://neovim.io/doc/user/api.html#nvim_set_hl()>)
 
 Styles can be applied to highlight groups:
 
@@ -450,7 +452,6 @@ The theme supports opinionated highlighting for filetypes, just like the origina
 - `vue`
 - `xml`
 - `yaml`
-
 
 Specific filetypes can be disabled as follows:
 
@@ -728,6 +729,8 @@ The theme supports the following plugins:
 - [marks.nvim](https://github.com/chentau/marks.nvim) (`marks`)
 - [mason.nvim](https://github.com/williamboman/mason.nvim) (`mason`)
 - [mini.indentscope](https://github.com/echasnovski/mini.indentscope) (`mini_indentscope`)
+- [mini.diff](https://github.com/echasnovski/mini.diff)(`mini_diff`)
+- [mini.icons](https://github.com/echasnovski/mini.icons)('mini_icons')
 - [Neotest](https://github.com/nvim-neotest/neotest) (`neotest`)
 - [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim) (`neo_tree`)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (`nvim_cmp`)

--- a/lua/onedarkpro/config.lua
+++ b/lua/onedarkpro/config.lua
@@ -95,6 +95,8 @@ local defaults = {
         vim_ultest = true,
         which_key = true,
         vim_dadbod_ui = true,
+        mini_diff = true,
+        mini_icons = true,
     },
     options = {
         cursorline = false, -- Use cursorline highlighting?

--- a/lua/onedarkpro/highlights/plugins/mini_diff.lua
+++ b/lua/onedarkpro/highlights/plugins/mini_diff.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.groups(theme)
+    return {
+        MiniDiffOverAdd = { link = "DiffAdd" },
+        MiniDiffOverChange = { link = "DiffChange" },
+        MiniDiffOverContext = { link = "DiffText" },
+        MiniDiffOverDelete = { link = "DiffDelete" },
+        MiniDiffSignAdd = { fg = theme.generated.git_add },
+        MiniDiffSignChange = { fg = theme.generated.git_change },
+        MiniDiffSignDelete = { fg = theme.generated.git_delete },
+    }
+end
+
+return M

--- a/lua/onedarkpro/highlights/plugins/mini_icons.lua
+++ b/lua/onedarkpro/highlights/plugins/mini_icons.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.groups(theme)
+    return {
+        MiniIconsGrey = { fg = theme.palette.gray },
+        MiniIconsPurple = { fg = theme.palette.purple },
+        MiniIconsBlue = { fg = theme.palette.blue },
+        MiniIconsAzure = { fg = theme.generated.virtual_text_information },
+        MiniIconsCyan = { fg = theme.palette.cyan },
+        MiniIconsGreen = { fg = theme.palette.green },
+        MiniIconsYellow = { fg = theme.palette.yellow },
+        MiniIconsOrange = { fg = theme.palette.orange },
+        MiniIconsRed = { fg = theme.palette.red },
+    }
+end
+
+return M


### PR DESCRIPTION
Add highlight groups for [mini.icons](https://github.com/echasnovski/mini.icons) and [mini.diff](https://github.com/echasnovski/mini.diff)

Before:
![image](https://github.com/user-attachments/assets/4d1102c6-7b41-40a6-b708-6199c054d6dd)
![image](https://github.com/user-attachments/assets/2d102d68-9c14-4825-91cb-b43c8e5603c1)

After:
![image](https://github.com/user-attachments/assets/62c2da27-b8c8-4a12-9e34-b65091cc12b3)
![image](https://github.com/user-attachments/assets/b8faebbf-bbed-4f7a-bf93-e11d88b6eaa9)
