### PR TITLE
feat(extras): Add Ghostty theme

### DIFF
--- a/extras/ghostty/onedarkpro_onedark
+++ b/extras/ghostty/onedarkpro_onedark
@@ -1,0 +1,23 @@
+# Colors - https://github.com/olimorris/onedarkpro.nvim
+
+palette = 0=#282c34
+palette = 1=#e06c75
+palette = 2=#98c379
+palette = 3=#e5c07b
+palette = 4=#61afef
+palette = 5=#c678dd
+palette = 6=#56b6c2
+palette = 7=#abb2bf
+palette = 8=#5c6370
+palette = 9=#e9969d
+palette = 10=#b3d39c
+palette = 11=#edd4a6
+palette = 12=#8fc6f4
+palette = 13=#d7a1e7
+palette = 14=#7bc6d0
+palette = 15=#c8cdd5
+background = #282c34
+foreground = #abb2bf
+cursor-color = #c678dd
+selection-background = #c678dd
+selection-foreground = #abb2bf

--- a/extras/ghostty/onedarkpro_onedark_dark
+++ b/extras/ghostty/onedarkpro_onedark_dark
@@ -1,0 +1,23 @@
+# Colors - https://github.com/olimorris/onedarkpro.nvim
+
+palette = 0=#000000
+palette = 1=#ef596f
+palette = 2=#89ca78
+palette = 3=#e5c07b
+palette = 4=#61afef
+palette = 5=#d55fde
+palette = 6=#2bbac5
+palette = 7=#abb2bf
+palette = 8=#434852
+palette = 9=#f38897
+palette = 10=#a9d89d
+palette = 11=#edd4a6
+palette = 12=#8fc6f4
+palette = 13=#e089e7
+palette = 14=#4bced8
+palette = 15=#c8cdd5
+background = #000000
+foreground = #abb2bf
+cursor-color = #d55fde
+selection-background = #d55fde
+selection-foreground = #abb2bf

--- a/extras/ghostty/onedarkpro_onedark_vivid
+++ b/extras/ghostty/onedarkpro_onedark_vivid
@@ -1,0 +1,23 @@
+# Colors - https://github.com/olimorris/onedarkpro.nvim
+
+palette = 0=#282c34
+palette = 1=#ef596f
+palette = 2=#89ca78
+palette = 3=#e5c07b
+palette = 4=#61afef
+palette = 5=#d55fde
+palette = 6=#2bbac5
+palette = 7=#abb2bf
+palette = 8=#5c6370
+palette = 9=#f38897
+palette = 10=#a9d89d
+palette = 11=#edd4a6
+palette = 12=#8fc6f4
+palette = 13=#e089e7
+palette = 14=#4bced8
+palette = 15=#c8cdd5
+background = #282c34
+foreground = #abb2bf
+cursor-color = #d55fde
+selection-background = #d55fde
+selection-foreground = #abb2bf

--- a/extras/ghostty/onedarkpro_onelight
+++ b/extras/ghostty/onedarkpro_onelight
@@ -1,0 +1,23 @@
+# Colors - https://github.com/olimorris/onedarkpro.nvim
+
+palette = 0=#6a6a6a
+palette = 1=#e05661
+palette = 2=#1da912
+palette = 3=#eea825
+palette = 4=#118dc3
+palette = 5=#9a77cf
+palette = 6=#56b6c2
+palette = 7=#fafafa
+palette = 8=#bebebe
+palette = 9=#e88189
+palette = 10=#25d717
+palette = 11=#f2bb54
+palette = 12=#1caceb
+palette = 13=#b69ddc
+palette = 14=#7bc6d0
+palette = 15=#ffffff
+background = #fafafa
+foreground = #6a6a6a
+cursor-color = #9a77cf
+selection-background = #9a77cf
+selection-foreground = #6a6a6a

--- a/lua/onedarkpro/extra/ghostty.lua
+++ b/lua/onedarkpro/extra/ghostty.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+M.template = [[
+# Colors - https://github.com/olimorris/onedarkpro.nvim
+
+palette = 0=${black}
+palette = 1=${red}
+palette = 2=${green}
+palette = 3=${yellow}
+palette = 4=${blue}
+palette = 5=${purple}
+palette = 6=${cyan}
+palette = 7=${white}
+palette = 8=${gray}
+palette = 9=${bright_red}
+palette = 10=${bright_green}
+palette = 11=${bright_yellow}
+palette = 12=${bright_blue}
+palette = 13=${bright_purple}
+palette = 14=${bright_cyan}
+palette = 15=${bright_white}
+background = ${bg}
+foreground = ${fg}
+cursor-color = ${purple}
+selection-background = ${purple}
+selection-foreground = ${fg}
+]]
+
+return M

--- a/lua/onedarkpro/extra/init.lua
+++ b/lua/onedarkpro/extra/init.lua
@@ -6,6 +6,7 @@ local M = {}
 M.extras = {
     alacritty = { ft = "toml", url = "https://github.com/alacritty/alacritty", label = "Alacritty" },
     foot = { ft = "dosini", url = "https://codeberg.org/dnkl/foot", label = "Foot" },
+    ghostty = { ft = "", url = "https://github.com/ghostty-org/ghostty", label = "Ghostty" },
     kitty = { ft = "conf", url = "https://github.com/kovidgoyal/kitty", label = "Kitty" },
     lazygit = { ft = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },
     rio = { ft = "toml", url = "https://github.com/raphamorim/rio", label = "Rio" },
@@ -72,7 +73,7 @@ function M.setup(opts)
             add_bright_colors(colors, theme)
             add_dim_colors(colors, theme)
             utils.write(
-                path .. extra .. "/onedarkpro_" .. theme .. "." .. M.extras[extra].ft,
+                path .. extra .. "/onedarkpro_" .. theme .. (M.extras[extra].ft ~= "" and ("." .. M.extras[extra].ft) or ""),
                 replace(extra_template, colors)
             )
         end


### PR DESCRIPTION
Adds support for [Ghostty](https://ghostty.org/) terminal.

Since Ghostty uses text-based configuration files with no extension, I also added support for this in `lua/onedarkpro/extra/init.lua` with usage denoted by `ft=""`. 