### PR TITLE
fix(treesitter): Markdown checkbox highlight fix

### DIFF
--- a/lua/onedarkpro/highlights/plugins/treesitter.lua
+++ b/lua/onedarkpro/highlights/plugins/treesitter.lua
@@ -98,7 +98,7 @@ function M.groups(theme)
         ["@markup.raw.delimiter"] = { fg = theme.palette.gray },
 
         ["@markup.list"] = { fg = theme.palette.red }, -- list markers
-        ["@markup.list.checked"] = { fg = theme.palette.purple, bg = theme.palette.bg }, -- checked todo-style list markers
+        ["@markup.list.checked"] = { fg = theme.palette.purple }, -- checked todo-style list markers
         ["@markup.list.unchecked"] = { fg = theme.palette.fg }, -- unchecked todo-style list markers
 
         -- Tags


### PR DESCRIPTION
The highlight group ["@markup.list.checked"] bg and fg colors were flipped and it looked scuffed. fg is now properly purple, and removing bg makes it look much better with transparency.

Here's what they look like with it broken:
![scuffed](https://github.com/user-attachments/assets/cd658187-fe95-4953-9ba9-124249349c59)

Fixed:
![fixed](https://github.com/user-attachments/assets/1ad88fd6-e053-4ad6-a198-c44d4491d5fd)

Transparent w/ bg:
![tpbg](https://github.com/user-attachments/assets/8b080b63-6da0-4292-988a-d28ab7d195ef)

Transparent w/o bg:
![tpnobg](https://github.com/user-attachments/assets/308a19d6-5c6e-48d0-bd7c-fdf798e27a0b)
