### PR TITLE
feat(snacks.indent): Added extra highlights for SnacksIndentScope

### DIFF
--- a/lua/onedarkpro/highlights/plugins/snacks.lua
+++ b/lua/onedarkpro/highlights/plugins/snacks.lua
@@ -4,22 +4,19 @@ local M = {}
 ---@param theme table
 ---@return table
 function M.groups(theme)
-    return {
+    local highlights = {
         -- https://github.com/folke/snacks.nvim
         SnacksIndent = { fg = theme.generated.indentline },
+        SnacksIndentScope = { fg = theme.palette.blue },
         SnacksPickerCol = { fg = theme.generated.line_number },
         SnacksPickerDir = { link = "Text" },
         SnacksPickerBufFlags = { link = "SnacksPickerDir" },
-        SnacksIndentScope = { fg = theme.palette.blue },
-        SnacksIndentScope1 = { fg = theme.palette.blue },
-        SnacksIndentScope2 = { fg = theme.palette.red },
-        SnacksIndentScope3 = { fg = theme.palette.orange },
-        SnacksIndentScope4 = { fg = theme.palette.yellow },
-        SnacksIndentScope5 = { fg = theme.palette.green },
-        SnacksIndentScope6 = { fg = theme.palette.cyan },
-        SnacksIndentScope7 = { fg = theme.palette.purple },
-        SnacksIndentScope8 = { fg = theme.palette.highlight },
     }
+    for i, color in ipairs(theme.rainbow) do
+        highlights["SnacksIndentScope" .. i] = { fg = color }
+    end
+
+    return highlights
 end
 
 return M

--- a/lua/onedarkpro/highlights/plugins/snacks.lua
+++ b/lua/onedarkpro/highlights/plugins/snacks.lua
@@ -11,6 +11,14 @@ function M.groups(theme)
         SnacksPickerDir = { link = "Text" },
         SnacksPickerBufFlags = { link = "SnacksPickerDir" },
         SnacksIndentScope = { fg = theme.palette.blue },
+        SnacksIndentScope1 = { fg = theme.palette.blue },
+        SnacksIndentScope2 = { fg = theme.palette.red },
+        SnacksIndentScope3 = { fg = theme.palette.orange },
+        SnacksIndentScope4 = { fg = theme.palette.yellow },
+        SnacksIndentScope5 = { fg = theme.palette.green },
+        SnacksIndentScope6 = { fg = theme.palette.cyan },
+        SnacksIndentScope7 = { fg = theme.palette.purple },
+        SnacksIndentScope8 = { fg = theme.palette.highlight },
     }
 end
 


### PR DESCRIPTION
Added the rest of the palette for SnacksIndentScope{1-8}, allowing users to have rainbow scope highlighting!

[Kooha-2025-04-16-17-06-18.webm](https://github.com/user-attachments/assets/2b0fc77b-b1d6-4416-9c56-f721a8b88b6e)

Usage:
```lua
indent = {
  scope = {
    hl = {
      "SnacksIndentScope1",
      "SnacksIndentScope2",
      "SnacksIndentScope3",
      "SnacksIndentScope4",
      "SnacksIndentScope5",
      "SnacksIndentScope6",
      "SnacksIndentScope7",
      "SnacksIndentScope8",
    }
  }
}
```