### PR TITLE
fix(Telescope): Properly highlight lines in preview

### DIFF
--- a/lua/onedarkpro/highlights/plugins/telescope.lua
+++ b/lua/onedarkpro/highlights/plugins/telescope.lua
@@ -27,6 +27,7 @@ function M.groups(theme)
         TelescopePromptNormal = { link = "TelescopeNormal" },
         TelescopePromptBorder = { link = "TelescopeBorder" },
         TelescopePreviewBorder = { link = "TelescopeBorder" },
+        TelescopePreviewLine = { link = "TelescopeSelection" },
         TelescopePromptPrefix = { fg = theme.palette.purple },
         TelescopeMatching = { fg = theme.palette.green },
     }


### PR DESCRIPTION
Thank you for maintaining this plugin!

With this change, the lines matching the prompt of `live_grep` are now correctly highlighted in the preview window of telescope.

Before:
<img width="1525" alt="before" src="https://github.com/user-attachments/assets/ffc9ec22-f119-4d9b-b1c0-9fa0835f0a58" />

After:
<img width="1520" alt="after" src="https://github.com/user-attachments/assets/660788fa-406e-43f5-adb5-53babeb08d2a" />
