### PR TITLE
Change DiagnosticUnderline from fg to sp

### DIFF
--- a/lua/onedarkpro/highlights/plugins/nvim_lsp.lua
+++ b/lua/onedarkpro/highlights/plugins/nvim_lsp.lua
@@ -19,10 +19,10 @@ function M.groups(theme)
         DiagnosticSignInfo = { fg = theme.palette.blue },
         DiagnosticSignHint = { fg = theme.palette.cyan },
 
-        DiagnosticUnderlineError = { fg = theme.palette.red, undercurl = true },
-        DiagnosticUnderlineWarn = { fg = theme.palette.yellow, undercurl = true },
-        DiagnosticUnderlineInfo = { fg = theme.palette.blue, undercurl = true },
-        DiagnosticUnderlineHint = { fg = theme.palette.cyan, undercurl = true },
+        DiagnosticUnderlineError = { sp = theme.palette.red, undercurl = true },
+        DiagnosticUnderlineWarn = { sp = theme.palette.yellow, undercurl = true },
+        DiagnosticUnderlineInfo = { sp = theme.palette.blue, undercurl = true },
+        DiagnosticUnderlineHint = { sp = theme.palette.cyan, undercurl = true },
 
         DiagnosticVirtualTextError = { fg = theme.generated.virtual_text_error, style = config.styles.virtual_text },
         DiagnosticVirtualTextWarn = { fg = theme.generated.virtual_text_warning, style = config.styles.virtual_text },


### PR DESCRIPTION
Diagnostic underlines currently cause the entire line to change to the color of the underline. By changing fg to sp, the normal text colors remain, just the underline is a certain color.
This is much less obtrusive. 