### PR TITLE
feat(python): add highlight for aliased imports in highlights.scm

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -5,6 +5,7 @@
 (dictionary_splat ("**" @odp.operator.splat))
 
 (import_statement name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))
+(import_statement name: (aliased_import name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126))))
 (import_from_statement name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))
 (import_from_statement module_name: (relative_import (dotted_name (identifier) @odp.import_module (#set! "priority" 126))))
 (import_from_statement module_name: (dotted_name (identifier) @odp.import_module (#set! "priority" 126)))


### PR DESCRIPTION
Before this pr, the `@odp.import_module` capture missed the `import xxx as yyy` case.

Not sure why the `CalledProcessError` is part of `@odp.import_module` highlight though. Attached the info below

<img width="1021" height="408" alt="image" src="https://github.com/user-attachments/assets/e7fb44d1-a566-4b9a-8a6a-8c745ed9cfdc" />

Inspect the highlight for `CalledProcessError`
<img width="1271" height="374" alt="image" src="https://github.com/user-attachments/assets/1f6e16f5-6229-4b0f-bd36-6eaa10038d90" />



